### PR TITLE
Handle path parameter substitution on a per-component basis

### DIFF
--- a/PapyrusCore/Sources/RequestBuilder.swift
+++ b/PapyrusCore/Sources/RequestBuilder.swift
@@ -188,13 +188,13 @@ public struct RequestBuilder {
     }
 
     private func parameterizedPath() throws -> String {
-        try parameters.reduce(into: path) { newPath, component in
-            guard newPath.contains(":\(component.key)") else {
+        try parameters.reduce(into: path.split(separator: "/")) { newPath, component in
+            guard let index = newPath.firstIndex(of: ":\(component.key)") else {
                 throw PapyrusError("Tried to set path parameter `\(component.key)` but did not find `:\(component.key)` in path `\(path)`.")
             }
 
-            newPath = newPath.replacingOccurrences(of: ":\(component.key)", with: component.value)
-        }
+            newPath[index] = component.value[...]
+        }.joined(separator: "/")
     }
 
     private func bodyData() throws -> Data? {

--- a/PapyrusCore/Tests/ParameterTests.swift
+++ b/PapyrusCore/Tests/ParameterTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import PapyrusCore
+
+final class ParameterTests: XCTestCase {
+    func testPath() {
+        var req = RequestBuilder(baseURL: "foo/", method: "GET", path: "bar/:baz")
+        req.addParameter("baz", value: "value")
+        XCTAssertEqual(try req.fullURL().absoluteString, "foo/bar/value")
+    }
+
+    func testPathPrefix() {
+        var req = RequestBuilder(baseURL: "foo/", method: "GET", path: "bar/:bazzar")
+        req.addParameter("baz", value: "value")
+        XCTAssertThrowsError(try req.fullURL().absoluteString, "foo/bar/value")
+    }
+
+    func testPathCommonPrefix() {
+        var req = RequestBuilder(baseURL: "foo/", method: "GET", path: "bar/:part/:partTwo")
+        req.addParameter("part", value: "valueOne")
+        req.addParameter("partTwo", value: "valueTwo")
+        XCTAssertEqual(try req.fullURL().absoluteString, "foo/bar/valueOne/valueTwo")
+    }
+}


### PR DESCRIPTION
When using `newPath.contains(_:)` and `newPath.replacingOccurences(of:with:)` on a String, you can run into issues when one key is a prefix of another key. For example, a path like `/:part/:partTwo` being substituted with `part: "valueOne", partTwo: "valueTwo"` will clobber the `partTwo` placeholder when substituting `part` (`/valueOne/valueOneTwo`). Relatedly, it also allows path parameters that only match a prefix of the placeholder in the path.

This PR first splits the path on `/` delimiters, only substitutes components that fully match the key, then re-joins the components into a path.