### PR TITLE
Fix RequestModifier: use modified _builder instead of orignal builder

### DIFF
--- a/PapyrusCore/Sources/Provider.swift
+++ b/PapyrusCore/Sources/Provider.swift
@@ -63,9 +63,9 @@ public final class Provider {
             try modifier.modify(req: &_builder)
         }
 
-        let url = try builder.fullURL()
-        let (body, headers) = try builder.bodyAndHeaders()
-        return http.build(method: builder.method, url: url, headers: headers, body: body)
+        let url = try _builder.fullURL()
+        let (body, headers) = try _builder.bodyAndHeaders()
+        return http.build(method: _builder.method, url: url, headers: headers, body: body)
     }
 }
 


### PR DESCRIPTION
In the createRequest Method of the Provider class is probably a minor error.
Instead of building the request with the modified _builder variable the original builder
was used. So all modifications are ignored. This PR fixes my issues when adding an Authentication Request Modifier:
This did not work before:

` struct AuthenticationMiddleware: RequestModifier {
    func modify(req: inout PapyrusCore.RequestBuilder) throws {
        req.addAuthorization(RequestBuilder.AuthorizationHeader.bearer(token))
    }
} `