### PR TITLE
add tvOS, watchOS compatiblity

### DIFF
--- a/PapyrusCore/Sources/ResponseDecoder.swift
+++ b/PapyrusCore/Sources/ResponseDecoder.swift
@@ -21,7 +21,7 @@ extension JSONDecoder: ResponseDecoder {
         new.nonConformingFloatDecodingStrategy = nonConformingFloatDecodingStrategy
 #if os(Linux)
 #else
-        if #available(iOS 15.0, macOS 12.0, *) {
+        if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
             new.assumesTopLevelDictionary = assumesTopLevelDictionary
             new.allowsJSON5 = allowsJSON5
         }


### PR DESCRIPTION
This PR adds extra checks to an if #available so compiling for newer tvOS and watchOS versions doesn't fail.