### PR TITLE
Add papyrus scope to generated code

### DIFF
--- a/PapyrusPlugin/Sources/APIMacro.swift
+++ b/PapyrusPlugin/Sources/APIMacro.swift
@@ -20,9 +20,9 @@ extension ProtocolDeclSyntax {
     func createAPI(named apiName: String) throws -> String {
         """
         \(access)struct \(apiName): \(typeName) {
-            private let provider: Provider
+            private let provider: Papyrus.Provider
 
-            \(access)init(provider: Provider) {
+            \(access)init(provider: Papyrus.Provider) {
                 self.provider = provider
             }
 

--- a/PapyrusPlugin/Tests/APIMacroTests.swift
+++ b/PapyrusPlugin/Tests/APIMacroTests.swift
@@ -45,9 +45,9 @@ final class APIMacroTests: XCTestCase {
             }
 
             struct FooAPI: Foo {
-                private let provider: Provider
+                private let provider: Papyrus.Provider
 
-                init(provider: Provider) {
+                init(provider: Papyrus.Provider) {
                     self.provider = provider
                 }
 
@@ -88,9 +88,9 @@ final class APIMacroTests: XCTestCase {
             }
 
             struct MyServiceAPI: MyService {
-                private let provider: Provider
+                private let provider: Papyrus.Provider
 
-                init(provider: Provider) {
+                init(provider: Papyrus.Provider) {
                     self.provider = provider
                 }
 
@@ -129,9 +129,9 @@ final class APIMacroTests: XCTestCase {
             }
 
             struct MyServiceAPI: MyService {
-                private let provider: Provider
+                private let provider: Papyrus.Provider
 
-                init(provider: Provider) {
+                init(provider: Papyrus.Provider) {
                     self.provider = provider
                 }
 
@@ -167,9 +167,9 @@ final class APIMacroTests: XCTestCase {
             }
 
             struct MyServiceAPI: MyService {
-                private let provider: Provider
+                private let provider: Papyrus.Provider
 
-                init(provider: Provider) {
+                init(provider: Papyrus.Provider) {
                     self.provider = provider
                 }
 
@@ -211,9 +211,9 @@ final class APIMacroTests: XCTestCase {
             }
 
             struct MyServiceAPI: MyService {
-                private let provider: Provider
+                private let provider: Papyrus.Provider
 
-                init(provider: Provider) {
+                init(provider: Papyrus.Provider) {
                     self.provider = provider
                 }
 
@@ -257,9 +257,9 @@ final class APIMacroTests: XCTestCase {
             }
 
             struct MyServiceAPI: MyService {
-                private let provider: Provider
+                private let provider: Papyrus.Provider
 
-                init(provider: Provider) {
+                init(provider: Papyrus.Provider) {
                     self.provider = provider
                 }
 


### PR DESCRIPTION
The generated code uses the `Provider` type specified in the package. However, if another `Provider` type is declared in the project, the wrong one will be chosen. This PR replaces the `Provider` references with `Papyrus.Provider`, resolving the type name clashes