### PR TITLE
Add special casing of Data return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,22 @@ Endpoint functions should return a type that conforms to `Decodable`. It will au
 func getUser() async throws -> User
 ```
 
+### Accessing just the body
+
+If you only need a response's raw body bytes, you can just return `Data` from your function.  
+
+```swift
+@GET("/bytes")
+func getBytes() async throws -> Data
+```
+
+The above will throw if the request body is empty, even if the status code is successful. If you don't want to throw in that case, set the response as `Data?`; it will successfully return nil if the response body is empty.
+
+```swift
+@GET("/bytes")
+func getBytes() async throws -> Data?
+```
+
 ### Empty responses
 
 If you don't need to decode something from the response and just want to confirm it was successful, you may leave out the return type.


### PR DESCRIPTION
This makes it so you can just return `Data` or `Data?` from your API function to easily access the raw response body. The first will throw an error if the response body is empty, the second will successfully return nil.

Issue #20.

```swift
@GET("/body")
func getBody() async throws -> Data

@GET("/optional_body")
func getOptionalBody() async throws -> Data?
```